### PR TITLE
add the storytime dataset

### DIFF
--- a/_posts/2022-08-29-the-storytime-dataset.md
+++ b/_posts/2022-08-29-the-storytime-dataset.md
@@ -1,0 +1,31 @@
+---
+access: Go to https://osf.io/cyb8w/. Then select "Download as zip" in the "Files" container.
+author: Quality and Usability Lab, TU Berlin
+categories:
+  - audiovisual
+citation: 'Please, cite the following paper, if you use this database: [STD22]'
+contact_name: Robert Spang
+contact_email: spang@tu-berlin.de
+database: The Storytime Dataset
+deprecated: false
+excerpt: 'Clips for simulated videotelephony. Four stories with ten parts each, four different quality levels per clip. German language.'
+external_link: https://osf.io/cyb8w/
+method: Custom
+partner: true
+publicly_available: true
+ratings: 2-11 per clip
+references:
+  STD22: "Spang, R.P., Voigt-Antons, J. N. & Möller, S. (2022, September). The Storytime Dataset: Simulated Videotelephony Clips for Quality Perception Research. In 2022 Fourteenth International Conference on Quality of Multimedia Experience (QoMEX) (pp. 1-6). IEEE."
+resolution: 1920x1080
+license: CC-By Attribution 4.0 International
+subjective_scores: true
+tags:
+  - audiovisual
+  - dataset
+  - degradation
+  - stimuli
+title: The Storytime Dataset
+total: 160
+---
+
+To study people's natural behavior during different conditions of audiovisual quality, we usually invite people into a lab and let them talk to each other. In such conversation settings, not only the media quality impacts the quality perception, but, e.g., social aspects of a real conversation are reflected by individual conversational and rating behavior. Hence, to study quality perception in conversational settings, we try to create an environment that isolates the media quality from such outside factors and is consistent for each participant in the lab. Therefore, we created a dataset of simulated videotelephony clips to act as stimuli in quality perception research. The dataset consists of four different stories in the German language that are told through ten consecutive parts, each about 10 seconds long. Each of these parts is available in four different quality levels, ranging from perfect to stalling. All clips (FullHD, H.264 / AAC) are actual recordings from end-user video-conference software to ensure ecological validity and realism of quality degradation. To ensure consistency among different clips of the same quality level, each video has been scored using VMAF and POLQA and selected to match predefined selection criteria. To analyze the perceived quality of the clips, we conducted a user study (N=25) and evaluated perceived quality, interest in the stories, and speaker engagement. Results validate the consistency of the quality levels of the video clips. Apart from a detailed description of the methodological approach, we contribute the entire stimuli dataset containing 160 videos and all rating scores for each file.


### PR DESCRIPTION
Dear all, this PR adds "The Storytime Dataset" to the list of databases. This audiovisual dataset contains 160 clips for simulated video-telephony and will be presented as a contribution to the upcoming QoMEX conference next week.